### PR TITLE
Save cookies on login

### DIFF
--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -21,6 +21,7 @@ const Login = () => {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify({ username, password }),
+            credentials: 'include',
         });
         const json = await response.json();
 


### PR DESCRIPTION
The fetch API doesn't receive/send any cookies by default ('credentials' is set to 'same-origin').

Fixes #3