### PR TITLE
Remove path from refresh token cookie

### DIFF
--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -33,7 +33,6 @@ router.post('/', async (req, res, next) => {
             httpOnly: true,
             domain: process.env.DOMAIN,
             maxAge: 604800000,
-            path: '/token',
             secure: process.env.NODE_ENV === 'production' ? true : false,
         });
         res.json({ refreshToken, accessToken });


### PR DESCRIPTION
Cookies with the `/token` path cannot be deleted on the `/login` route.